### PR TITLE
Translate court types and surfaces values to Polish

### DIFF
--- a/src/components/CourtGroupRow.jsx
+++ b/src/components/CourtGroupRow.jsx
@@ -40,16 +40,16 @@ const CourtGroupRow = ({ courtGroup, groupIndex, isMobile, startTime, endTime, s
             <Grid2 id="court-type-grid" size={ isMobile ? 12 : 3 }>
                 { isMobile || isClosed ? (
                     <Typography variant="body2" sx={{ mb: 1 }}>
-                        {t('Court type')}: {`${courtGroup.surface} | ${courtGroup.type} `}
+                        {t('Court type')}: {`${t(courtGroup.surface)} | ${t(courtGroup.type)} `}
                     </Typography>
                 ) : (
                     <>
                         <Typography variant="body2" sx={{ mb: 1 }}>
-                            {t('Court type')}: {courtGroup.type}
+                            {t('Court type')}: {t(courtGroup.type)}
                         </Typography>                                                
 
                         <Typography variant="body2" sx={{ mb: 1 }}>
-                            {t('Surface')}: {courtGroup.surface}
+                            {t('Surface')}: {t(courtGroup.surface)}
                         </Typography>
                     </>
                 )}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -21,7 +21,16 @@ const resources = {
       "weekdays": "tydzień",
       "Show Closed Courts": "Pokaż zamknięte korty",
       "hour": "godzina",
-      "No heating": "Bez ogrzewania"
+      "No heating": "Bez ogrzewania",
+      "indoor": "wewnętrzny",
+      "outdoor": "zewnętrzny",
+      "tent": "namiot",
+      "baloon": "balon",
+      "hard": "twarda",
+      "clay": "ziemna",
+      "grass": "trawa",
+      "carpet": "dywan",
+      "artificial-grass": "sztuczna trawa"
     }
   },  
   en: {


### PR DESCRIPTION
Add translations for court types and surfaces values to Polish.

* **src/i18n.js**
  - Add translations for court types and surfaces values in the `resources` object.

* **src/components/CourtGroupRow.jsx**
  - Translate court types and surfaces values using the `t` function from `react-i18next`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DenisPalnitsky/korty-wroclawia/pull/18?shareId=4c6f94af-b2a0-43b4-810b-ef05e3a054a8).