### PR TITLE
Datetime picker is localized and translated into Polish

### DIFF
--- a/src/components/ClubViewer.jsx
+++ b/src/components/ClubViewer.jsx
@@ -16,6 +16,8 @@ import CourtGroupRow from './CourtGroupRow';
 import CourtPricingSystem from '../CourtPricingSystem';
 import { useTranslation } from 'react-i18next';
 import OrderBySelector from './OrderBySelector';
+import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import AdapterDateFns from '@mui/x-date-pickers/AdapterDateFns';
 
 const marks = Array.from({ length: 49 }, (_, i) => {
   const hour = Math.floor(i / 2);
@@ -109,15 +111,17 @@ const ClubViewer = ({ pricingSystem, isMobile }) => {
         mb: 3
       }}>
 
-        <TextField
-          type="date"
-          label={t('Select Date')}
-          value={selectedDate}
-          onChange={(e) => { 
-            setSelectedDate(e.target.value);
-            setOrderedClubs(order, getDates().startTime, getDates().endTime);          }}
-          sx={{ minWidth: '160px' }}
-        />
+        <LocalizationProvider dateAdapter={AdapterDateFns} locale={pl}>
+          <DatePicker
+            label={t('Select Date')}
+            value={selectedDate}
+            onChange={(newValue) => {
+              setSelectedDate(newValue);
+              setOrderedClubs(order, getDates().startTime, getDates().endTime);
+            }}
+            renderInput={(params) => <TextField {...params} sx={{ minWidth: '160px' }} />}
+          />
+        </LocalizationProvider>
 
 
         <Box id="slider-box" sx={{ display: 'flex', width: "100%", gap: 2, flexDirection: isMobile ? 'column' : 'row', }}>

--- a/src/components/CourtGroupRow.jsx
+++ b/src/components/CourtGroupRow.jsx
@@ -17,6 +17,7 @@ import AcUnitIcon from '@mui/icons-material/AcUnit';
 
 const CourtGroupRow = ({ courtGroup, groupIndex, isMobile, startTime, endTime, showClosedCourts }) => {
     const { t } = useTranslation();
+
     const isClosed =  courtGroup.isClosed(startTime);
 
     if (isClosed && !showClosedCourts) {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,5 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import { pl, enUS } from 'date-fns/locale';
+
 
 const resources = {
   pl: {
@@ -43,6 +45,15 @@ const resources = {
 Object.keys(resources.pl.translation).forEach(key => {
   resources.en.translation[key] = key;
 });
+
+const dateFnsLocales = {
+  pl,
+  en: enUS
+};
+
+i18n.getDateFnsLocale = () => {
+  return dateFnsLocales[i18n.language] || dateFnsLocales.en;
+};
 
 i18n
   .use(initReactI18next)


### PR DESCRIPTION
Localize and translate the datetime picker in `src/components/ClubViewer.jsx` into Polish.

* **Import necessary modules:**
  - Import `DatePicker` and `LocalizationProvider` from `@mui/x-date-pickers`.
  - Import `AdapterDateFns` from `@mui/x-date-pickers/AdapterDateFns`.
  - Import `pl` locale from `date-fns/locale`.

* **Replace TextField with DatePicker:**
  - Replace the `TextField` used for date selection with `DatePicker` wrapped in `LocalizationProvider`.
  - Set the `locale` prop of `LocalizationProvider` to `pl`.
  - Adjust the `onChange` handler to use the new `DatePicker`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DenisPalnitsky/korty-wroclawia/pull/21?shareId=5d3fe818-1ad1-4459-b767-cf173a344633).